### PR TITLE
Fix/invalid files

### DIFF
--- a/app/controllers/FileListController.scala
+++ b/app/controllers/FileListController.scala
@@ -89,7 +89,16 @@ class FileListController @Inject() (cc:ControllerComponents,
           logger.debug(s"Collected presentable file $elem")
           elem
         })
-        .map(_.asJson.noSpaces)
+        .map(elem=>{
+          try {
+            logger.debug(s"converting to json")
+            elem.asJson.noSpaces
+          } catch {
+            case err:Throwable=>
+              logger.error(s"json conversion for ${elem.oid} failed: ${err.getMessage}", err)
+              throw err
+          }
+        })
         .map(elem=>{
           logger.debug(s"Got JSON string $elem")
           elem

--- a/app/controllers/FileListController.scala
+++ b/app/controllers/FileListController.scala
@@ -75,6 +75,7 @@ class FileListController @Inject() (cc:ControllerComponents,
 
       val outlet = lookup.out
         .map(PresentableFile.fromObjectMatrixEntry)
+        .collect({case Some(presentableFile)=>presentableFile})
         .map(_.asJson.noSpaces)
         .map(jsonString => ByteString(jsonString + "\n"))
         .outlet

--- a/app/controllers/FileListController.scala
+++ b/app/controllers/FileListController.scala
@@ -74,9 +74,26 @@ class FileListController @Inject() (cc:ControllerComponents,
       src ~> lookup
 
       val outlet = lookup.out
+        .log("FileListController.searchGraph")
+        .map(elem=>{
+          logger.debug(s"Got stream element $elem")
+          elem
+        })
         .map(PresentableFile.fromObjectMatrixEntry)
+        .map(elem=>{
+          logger.debug(s"Got presentable file $elem")
+          elem
+        })
         .collect({case Some(presentableFile)=>presentableFile})
+        .map(elem=>{
+          logger.debug(s"Collected presentable file $elem")
+          elem
+        })
         .map(_.asJson.noSpaces)
+        .map(elem=>{
+          logger.debug(s"Got JSON string $elem")
+          elem
+        })
         .map(jsonString => ByteString(jsonString + "\n"))
         .outlet
       SourceShape(outlet)

--- a/app/controllers/FileListController.scala
+++ b/app/controllers/FileListController.scala
@@ -75,33 +75,16 @@ class FileListController @Inject() (cc:ControllerComponents,
 
       val outlet = lookup.out
         .log("FileListController.searchGraph")
-        .map(elem=>{
-          logger.debug(s"Got stream element $elem")
-          elem
-        })
         .map(PresentableFile.fromObjectMatrixEntry)
-        .map(elem=>{
-          logger.debug(s"Got presentable file $elem")
-          elem
-        })
         .collect({case Some(presentableFile)=>presentableFile})
         .map(elem=>{
-          logger.debug(s"Collected presentable file $elem")
-          elem
-        })
-        .map(elem=>{
           try {
-            logger.debug(s"converting to json")
             elem.asJson.noSpaces
           } catch {
             case err:Throwable=>
               logger.error(s"json conversion for ${elem.oid} failed: ${err.getMessage}", err)
               throw err
           }
-        })
-        .map(elem=>{
-          logger.debug(s"Got JSON string $elem")
-          elem
         })
         .map(jsonString => ByteString(jsonString + "\n"))
         .outlet

--- a/app/models/FileAttributes.scala
+++ b/app/models/FileAttributes.scala
@@ -3,13 +3,13 @@ import java.time.{Instant, ZoneId, ZonedDateTime}
 
 import com.om.mxs.client.japi.MXFSFileAttributes
 
-case class FileAttributes(fileKey:String, name:String, parent:String, isDir:Boolean, isOther:Boolean, isRegular:Boolean, isSymlink:Boolean, ctime:ZonedDateTime, mtime:ZonedDateTime, atime:ZonedDateTime, size:Long)
+case class FileAttributes(fileKey:String, name:String, parent:Option[String], isDir:Boolean, isOther:Boolean, isRegular:Boolean, isSymlink:Boolean, ctime:ZonedDateTime, mtime:ZonedDateTime, atime:ZonedDateTime, size:Long)
 
 object FileAttributes {
   def apply(from:MXFSFileAttributes) = new FileAttributes(
     from.fileKey().toString,
     from.getName,
-    from.getParent,
+    Option(from.getParent),
     from.isDirectory,
     from.isOther,
     from.isRegularFile,

--- a/app/models/PresentableFile.scala
+++ b/app/models/PresentableFile.scala
@@ -8,7 +8,7 @@ case class PresentableFile(oid:String, attributes: FileAttributes, gnmMetadata: 
 
 object PresentableFile extends ((String, FileAttributes,Option[GnmMetadata], Option[String])=>PresentableFile) {
   def fromObjectMatrixEntry(src:ObjectMatrixEntry):Option[PresentableFile] =
-    src.fileAttribues.map(attribs=>PresentableFile(src.oid, attribs, GnmMetadata.fromObjectMatrixEntry(src) ,src.attributes.map(_.dumpString(None))))
+    src.fileAttribues.map(attribs=> PresentableFile(src.oid, attribs, GnmMetadata.fromObjectMatrixEntry(src) ,src.attributes.map(_.dumpString(None))))
 
 }
 

--- a/frontend/__tests__/searchnbrowse/TestEntrySummaryLi.jsx
+++ b/frontend/__tests__/searchnbrowse/TestEntrySummaryLi.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+import {shallow} from "enzyme";
+import sinon from "sinon";
+import EntrySummaryLi from "../../app/searchnbrowse/EntrySummaryLi";
+
+describe("EntrySummaryLi", ()=>{
+    it("should render a list entry with the given object details", ()=>{
+        const mockCb = sinon.spy();
+        const fakeEntry = {
+            "oid": "1234567",
+            "attributes": {
+                name: "path/to/some/file.mxf",
+                size: 1234,
+                ctime: "2020-01-02T03:04:05Z"
+            },
+            "metadata": "KEY=value, ANOTHERKEY=anothervalue"
+        };
+
+        const rendered = shallow(<EntrySummaryLi entry={fakeEntry} entryClickedCb={mockCb}/>);
+
+        expect(rendered.find("li.clickable")).toBeTruthy();
+        expect(rendered.find("p.filename").text()).toEqual("file.mxf");
+        const sups = rendered.find("p.supplementary");
+        expect(sups.length).toEqual(2);
+        expect(sups.at(0).text()).toEqual("1234 ");
+        expect(sups.at(1).text()).toEqual("2020-01-02T03:04:05Z");
+        expect(rendered.find("FontAwesomeIcon").length).toEqual(0);
+    });
+
+    it("should show a rubbish bin icon if MXFS_INTRASH=true", ()=>{
+        const mockCb = sinon.spy();
+        const fakeEntry = {
+            "oid": "1234567",
+            "attributes": {
+                name: "path/to/some/file.mxf",
+                size: 1234,
+                ctime: "2020-01-02T03:04:05Z"
+            },
+            "metadata": "KEY=value, ANOTHERKEY=anothervalue, MXFS_INTRASH=true"
+        };
+
+        const rendered = shallow(<EntrySummaryLi entry={fakeEntry} entryClickedCb={mockCb}/>);
+
+        expect(rendered.find("li.clickable")).toBeTruthy();
+        expect(rendered.find("p.filename").text()).toEqual("file.mxf");
+        const sups = rendered.find("p.supplementary");
+        expect(sups.length).toEqual(2);
+        expect(sups.at(0).text()).toEqual("1234 <FontAwesomeIcon />");
+        expect(sups.at(1).text()).toEqual("2020-01-02T03:04:05Z");
+        const icon = rendered.find("FontAwesomeIcon");
+        expect(icon.length).toEqual(1);
+        expect(icon.prop("icon")).toEqual("trash-alt");
+    });
+})

--- a/frontend/app/common/DownloadButton.jsx
+++ b/frontend/app/common/DownloadButton.jsx
@@ -32,6 +32,7 @@ class DownloadButton extends React.Component {
                 console.log("token download uri is ", serverData.uri);
                 a.href = serverData.uri;
                 a.download = this.props.fileName;
+                a.target = "_blank";
                 a.click();
                 this.setState({downloading: false, succeeded: true, lastError: null});
                 break;

--- a/frontend/app/index.jsx
+++ b/frontend/app/index.jsx
@@ -6,13 +6,13 @@ import Raven from 'raven-js';
 import SearchComponent from './SearchComponent.jsx';
 import { library } from '@fortawesome/fontawesome-svg-core'
 import OAuthCallbackComponent from "./OAuthCallbackComponent.jsx";
-import { faFolder, faFolderOpen, faTimes, faSearch, faCog } from '@fortawesome/free-solid-svg-icons'
+import { faFolder, faFolderOpen, faTimes, faSearch, faCog, faTrashAlt } from '@fortawesome/free-solid-svg-icons'
 import ByProjectComponent from "./ByProjectComponent.jsx";
 import LoadingIndicator from "./LoadingIndicator.jsx";
 import {authenticatedFetch} from "./auth";
 import LoginButton from "./LoginButton.jsx";
 
-library.add(faFolderOpen, faFolder, faTimes, faSearch, faCog);
+library.add(faFolderOpen, faFolder, faTimes, faSearch, faCog, faTrashAlt);
 
 class App extends React.Component {
     constructor(props){

--- a/frontend/app/index.jsx
+++ b/frontend/app/index.jsx
@@ -6,7 +6,8 @@ import Raven from 'raven-js';
 import SearchComponent from './SearchComponent.jsx';
 import { library } from '@fortawesome/fontawesome-svg-core'
 import OAuthCallbackComponent from "./OAuthCallbackComponent.jsx";
-import { faFolder, faFolderOpen, faTimes, faSearch, faCog, faTrashAlt } from '@fortawesome/free-solid-svg-icons'
+import { faTrashAlt } from '@fortawesome/free-regular-svg-icons';
+import { faFolder, faFolderOpen, faTimes, faSearch, faCog } from '@fortawesome/free-solid-svg-icons'
 import ByProjectComponent from "./ByProjectComponent.jsx";
 import LoadingIndicator from "./LoadingIndicator.jsx";
 import {authenticatedFetch} from "./auth";

--- a/frontend/app/index.jsx
+++ b/frontend/app/index.jsx
@@ -11,7 +11,6 @@ import { faFolder, faFolderOpen, faTimes, faSearch, faCog } from '@fortawesome/f
 import ByProjectComponent from "./ByProjectComponent.jsx";
 import LoadingIndicator from "./LoadingIndicator.jsx";
 import {authenticatedFetch} from "./auth";
-import LoginButton from "./LoginButton.jsx";
 
 library.add(faFolderOpen, faFolder, faTimes, faSearch, faCog, faTrashAlt);
 

--- a/frontend/app/metadata/CommissionProjectView.jsx
+++ b/frontend/app/metadata/CommissionProjectView.jsx
@@ -16,6 +16,7 @@ class CommissionProjectView extends React.Component {
         super(props);
         this.clickedProject = this.clickedProject.bind(this);
     }
+
     shouldDisplay(){
         if(!this.props.entry) return false;
         if(!this.props.entry.gnmMetadata) return false;

--- a/frontend/app/searchnbrowse/EntrySummaryLi.jsx
+++ b/frontend/app/searchnbrowse/EntrySummaryLi.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
 /**
  * render an entry for a list summary
@@ -14,11 +15,11 @@ class EntrySummaryLi extends React.Component {
         const entry = this.props.entry;
         const pathParts = entry.attributes.name.split("/");
         const fileName = pathParts.length>0 ? pathParts[pathParts.length - 1] : "(no name)";
-
+        const isInTrash = entry.metadata.includes("MXFS_INTRASH=true")
 
         return <li key={entry.oid} className="clickable" onClick={()=>this.props.entryClickedCb(entry)}>
             <p className="filename">{fileName}</p>
-            <p className="supplementary">{entry.attributes.size}</p>
+            <p className="supplementary">{entry.attributes.size} { isInTrash ? <FontAwesomeIcon icon="trash-alt" style={{marginLeft: "1em", height: "1em"}}/> : null}</p>
             <p className="supplementary">{entry.attributes.ctime}</p>
         </li>
     }

--- a/frontend/app/searchnbrowse/EntrySummaryLi.jsx
+++ b/frontend/app/searchnbrowse/EntrySummaryLi.jsx
@@ -15,7 +15,7 @@ class EntrySummaryLi extends React.Component {
         const entry = this.props.entry;
         const pathParts = entry.attributes.name.split("/");
         const fileName = pathParts.length>0 ? pathParts[pathParts.length - 1] : "(no name)";
-        const isInTrash = entry.metadata.includes("MXFS_INTRASH=true")
+        const isInTrash = (entry.hasOwnProperty("metadata") && entry.metadata) ? entry.metadata.includes("MXFS_INTRASH=true") : false;
 
         return <li key={entry.oid} className="clickable" onClick={()=>this.props.entryClickedCb(entry)}>
             <p className="filename">{fileName}</p>


### PR DESCRIPTION
## What does this change?
Files with a `null` parent ID would break the search stream, causing iteration to fail and potentially no results to be displayed. This fixes that issue.

