### PR TITLE
Basic Find Duplicates Interface

### DIFF
--- a/app/controllers/VaultController.scala
+++ b/app/controllers/VaultController.scala
@@ -1,10 +1,10 @@
 package controllers
 
 import akka.actor.{ActorRef, ActorSystem}
-import akka.stream.scaladsl.{GraphDSL, Source}
-import akka.stream.{Attributes, Materializer, SourceShape}
+import akka.stream.scaladsl.{GraphDSL, RunnableGraph, Sink, Source}
+import akka.stream.{Attributes, ClosedShape, Materializer, SourceShape}
 import auth.{BearerTokenAuth, Security}
-import com.om.mxs.client.japi.{MatrixStore, UserInfo, Vault}
+import com.om.mxs.client.japi.{MatrixStore, SearchTerm, UserInfo, Vault}
 import helpers.{RangeHeader, UserInfoCache, ZonedDateTimeEncoder}
 
 import javax.inject.{Inject, Named, Singleton}
@@ -15,9 +15,9 @@ import play.api.mvc.{AbstractController, AnyContent, ControllerComponents, Reque
 import responses.{GenericErrorResponse, KnownVaultResponse, SingleItemDownloadTokenResponse}
 import io.circe.generic.auto._
 import io.circe.syntax._
-import models.{AuditEvent, AuditFile, ObjectMatrixEntry, ServerTokenDAO, ServerTokenEntry}
+import models.{AuditEvent, AuditFile, CachedEntry, ExistingArchiveContentCache, ObjectMatrixEntry, ServerTokenDAO, ServerTokenEntry}
 import play.api.http.HttpEntity
-import streamcomponents.{AuditLogFinish, MatrixStoreFileSourceWithRanges, MultipartSource}
+import streamcomponents.{AuditLogFinish, MatrixStoreFileSourceWithRanges, MultipartSource, OMFastSearchSource}
 import akka.pattern.ask
 
 import scala.concurrent.Future
@@ -227,4 +227,85 @@ class VaultController @Inject() (cc:ControllerComponents,
       }
     }
   }
+
+  def loadExistingContent(vaultId: String) = {
+    val interestingFields = Array(
+      "MXFS_PATH",
+      "MXFS_FILENAME",
+      "GNM_ASSET_FOLDER",
+      "GNM_TYPE",
+      "GNM_PROJECT_ID"
+    )
+
+    val catchAllSearchTerm = SearchTerm.createNOTTerm(SearchTerm.createSimpleTerm("oid", ""))
+    val finalSink = Sink.seq[CachedEntry]
+    val content = userInfoCache.infoForVaultId(vaultId)
+    //implicit val vault:Vault = MatrixStore.openVault(content.head)
+    val graph = GraphDSL.create(finalSink) { implicit builder =>
+      sink =>
+        import akka.stream.scaladsl.GraphDSL.Implicits._
+
+        val src = builder.add(new OMFastSearchSource(content.head, Array(catchAllSearchTerm), interestingFields, atOnce = 100))
+        src.out.map(elem => {
+          //val mxsEntry = vault.getObject(elem.oid)
+          //val checkSum = MetadataHelper.getOMFileMd5(mxsEntry) match {
+          //  case Failure(err)=>
+          //    logger.warn(s"Could not get appliance MD5: ", err)
+          //    "None"
+          //  case Success(checksum)=>checksum
+          //}
+          val ent = CachedEntry(
+            elem.oid,
+            elem.attributes.flatMap(_.stringValues.get("MXFS_PATH")).getOrElse("(no path)"),
+            elem.attributes.flatMap(_.stringValues.get("MXFS_FILENAME")).getOrElse("(no filename)"),
+            elem.attributes.flatMap(_.stringValues.get("GNM_ASSET_FOLDER")),
+            elem.attributes.flatMap(_.stringValues.get("GNM_TYPE")),
+            elem.attributes.flatMap(_.stringValues.get("GNM_PROJECT_ID")),
+            ""
+          )
+
+          logger.debug(s"Got entry $ent")
+          ent
+        }) ~> sink
+        ClosedShape
+    }
+
+    RunnableGraph.fromGraph(graph).run()
+  }
+
+  case class FullDuplicateData(mxfsPath:String, duplicateNumber:Int, duplicatesData:Seq[CachedEntry])
+  case class AllDuplicateData(dupes_count:Int, item_count:Int, duplicates:Array[FullDuplicateData])
+
+  def getDuplicateData(vaultId: String)  = {
+    loadExistingContent(vaultId).map(results=>{
+      val contentCache = new ExistingArchiveContentCache(results)
+      var duplicatesArray: Array[FullDuplicateData] = Array()
+      val dupeCount = contentCache.dupesCount
+      if (dupeCount > 0) {
+        logger.warn(s"There are $dupeCount duplicated files in the archive")
+        contentCache.dupedPaths.foreach(dupe => {
+          logger.debug(s"${dupe._1}: ${dupe._2} copies")
+          val duplicatedItemData = contentCache.getAllForPath(dupe._1)
+          val duplicateDataThree = FullDuplicateData(dupe._1,dupe._2,duplicatedItemData)
+          duplicatesArray +:= duplicateDataThree
+        })
+      } else {
+        logger.info(s"No duplicates found.")
+      }
+      logger.info(s"Got existing ${results.length} items in the vault")
+      logger.info(s"${duplicatesArray}")
+      val fullDuplicateDataTwo = AllDuplicateData(dupes_count = contentCache.dupesCount, item_count = results.length, duplicates = duplicatesArray)
+      logger.info(s"${fullDuplicateDataTwo}")
+      fullDuplicateDataTwo
+    })
+  }
+
+  def findDuplicates(vaultId:String) = IsAuthenticatedAsync { uid=> request=>
+    getDuplicateData(vaultId).map(result=>{
+      Ok(result.asJson)}
+    ).recover({
+      case _:Throwable=> BadRequest(GenericErrorResponse("error", "An error occurred when attempting to load duplicate data.").asJson)
+    })
+  }
+
 }

--- a/app/models/CachedEntry.scala
+++ b/app/models/CachedEntry.scala
@@ -1,0 +1,3 @@
+package models
+
+case class CachedEntry(oid:String, mxfsPath:String, mxfsFilename:String, maybeAssetFolder:Option[String], maybeType:Option[String], maybeProject:Option[String], checkSum:String)

--- a/app/models/ExistingArchiveContentCache.scala
+++ b/app/models/ExistingArchiveContentCache.scala
@@ -1,0 +1,39 @@
+package models
+
+import org.slf4j.LoggerFactory
+
+class ExistingArchiveContentCache(rawData:Seq[CachedEntry]) {
+  private val logger = LoggerFactory.getLogger(getClass)
+  private val byPathMap = rawData.foldLeft(Map[String, Seq[CachedEntry]]())((acc, elem)=>{
+    acc.get(elem.mxfsPath) match {
+      case Some(existingElem)=>
+        acc + (elem.mxfsPath -> (existingElem :+ elem) )
+      case None=>
+        acc + (elem.mxfsPath -> Seq(elem))
+    }
+  })
+
+  def getAllForPath(path:String) = byPathMap.getOrElse(path, Seq())
+
+  def getFirstForPath(path:String) = byPathMap.get(path).flatMap(_.headOption)
+
+  def countForPath(path:String) = {
+    val count = byPathMap.get(path).map(_.length).getOrElse(0)
+    logger.debug(s"Path $path has $count matches in the archive")
+    count
+  }
+
+  def count = byPathMap.values.foldLeft(0)((acc, elem)=>acc + elem.length)
+
+  /**
+    * returns a count of the number of paths that have multiple items
+    * @return
+    */
+  def dupesCount = byPathMap.values.count(_.length>1)
+
+  /**
+    * returns a list of the paths that have multiple items
+    * @return a Map containing the path as a string and the number of assocaited items as an integer
+    */
+  def dupedPaths = byPathMap.filter(_._2.length>1).map(el=>(el._1, el._2.length))
+}

--- a/app/services/DuplicateFinderService.scala
+++ b/app/services/DuplicateFinderService.scala
@@ -1,0 +1,80 @@
+package services
+
+import org.slf4j.LoggerFactory
+import akka.stream.{ClosedShape, Materializer}
+import akka.stream.scaladsl.{GraphDSL, RunnableGraph, Sink}
+import com.om.mxs.client.japi.SearchTerm
+import helpers.UserInfoCache
+import models.{CachedEntry, ExistingArchiveContentCache}
+import streamcomponents.OMFastSearchSource
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+
+@Singleton
+class DuplicateFinderService @Inject()(userInfoCache:UserInfoCache)(implicit mat:Materializer){
+  private val logger = LoggerFactory.getLogger(getClass)
+
+
+  def loadExistingContent(vaultId: String) = {
+    val interestingFields = Array(
+      "MXFS_PATH",
+      "MXFS_FILENAME",
+      "GNM_ASSET_FOLDER",
+      "GNM_TYPE",
+      "GNM_PROJECT_ID"
+    )
+
+    val catchAllSearchTerm = SearchTerm.createNOTTerm(SearchTerm.createSimpleTerm("oid", ""))
+    val finalSink = Sink.seq[CachedEntry]
+    val content = userInfoCache.infoForVaultId(vaultId)
+    val graph = GraphDSL.create(finalSink) { implicit builder =>
+      sink =>
+        import akka.stream.scaladsl.GraphDSL.Implicits._
+
+        val src = builder.add(new OMFastSearchSource(content.head, Array(catchAllSearchTerm), interestingFields, atOnce = 100))
+        src.out.map(elem => {
+          val ent = CachedEntry(
+            elem.oid,
+            elem.attributes.flatMap(_.stringValues.get("MXFS_PATH")).getOrElse("(no path)"),
+            elem.attributes.flatMap(_.stringValues.get("MXFS_FILENAME")).getOrElse("(no filename)"),
+            elem.attributes.flatMap(_.stringValues.get("GNM_ASSET_FOLDER")),
+            elem.attributes.flatMap(_.stringValues.get("GNM_TYPE")),
+            elem.attributes.flatMap(_.stringValues.get("GNM_PROJECT_ID")),
+            ""
+          )
+
+          logger.debug(s"Got entry $ent")
+          ent
+        }) ~> sink
+        ClosedShape
+    }
+
+    RunnableGraph.fromGraph(graph).run()
+  }
+
+  case class FullDuplicateData(mxfsPath:String, duplicateNumber:Int, duplicatesData:Seq[CachedEntry])
+  case class AllDuplicateData(dupes_count:Int, item_count:Int, duplicates:Array[FullDuplicateData])
+
+  def getDuplicateData(vaultId: String)  = {
+    loadExistingContent(vaultId).map(results=>{
+      val contentCache = new ExistingArchiveContentCache(results)
+      var duplicatesArray: Array[FullDuplicateData] = Array()
+      val dupeCount = contentCache.dupesCount
+      if (dupeCount > 0) {
+        logger.warn(s"There are $dupeCount duplicated files in the archive")
+        contentCache.dupedPaths.foreach(dupe => {
+          logger.debug(s"${dupe._1}: ${dupe._2} copies")
+          val duplicatedItemData = contentCache.getAllForPath(dupe._1)
+          val duplicateDataThree = FullDuplicateData(dupe._1,dupe._2,duplicatedItemData)
+          duplicatesArray +:= duplicateDataThree
+        })
+      } else {
+        logger.info(s"No duplicates found.")
+      }
+      logger.info(s"Got existing ${results.length} items in the vault")
+      val duplicateDataToReturn = AllDuplicateData(dupes_count = contentCache.dupesCount, item_count = results.length, duplicates = duplicatesArray)
+      duplicateDataToReturn
+    })
+  }
+}

--- a/app/services/DuplicateFinderService.scala
+++ b/app/services/DuplicateFinderService.scala
@@ -54,24 +54,22 @@ class DuplicateFinderService @Inject()(userInfoCache:UserInfoCache)(implicit mat
   }
 
   case class FullDuplicateData(mxfsPath:String, duplicateNumber:Int, duplicatesData:Seq[CachedEntry])
-  case class AllDuplicateData(dupes_count:Int, item_count:Int, duplicates:Array[FullDuplicateData])
+  case class AllDuplicateData(dupes_count:Int, item_count:Int, duplicates:Seq[FullDuplicateData])
 
   def getDuplicateData(vaultId: String)  = {
     loadExistingContent(vaultId).map(results=>{
       val contentCache = new ExistingArchiveContentCache(results)
-      var duplicatesArray: Array[FullDuplicateData] = Array()
       val dupeCount = contentCache.dupesCount
       if (dupeCount > 0) {
         logger.warn(s"There are $dupeCount duplicated files in the archive")
-        contentCache.dupedPaths.foreach(dupe => {
-          logger.debug(s"${dupe._1}: ${dupe._2} copies")
-          val duplicatedItemData = contentCache.getAllForPath(dupe._1)
-          val duplicateDataThree = FullDuplicateData(dupe._1,dupe._2,duplicatedItemData)
-          duplicatesArray +:= duplicateDataThree
-        })
       } else {
         logger.info(s"No duplicates found.")
       }
+      val duplicatesArray = contentCache.dupedPaths.map(dupe=>{
+        logger.debug(s"${dupe._1}: ${dupe._2} copies")
+        val duplicatedItemData = contentCache.getAllForPath(dupe._1)
+        FullDuplicateData(dupe._1, dupe._2, duplicatedItemData)
+      }).toSeq
       logger.info(s"Got existing ${results.length} items in the vault")
       val duplicateDataToReturn = AllDuplicateData(dupes_count = contentCache.dupesCount, item_count = results.length, duplicates = duplicatesArray)
       duplicateDataToReturn

--- a/conf/routes
+++ b/conf/routes
@@ -17,6 +17,7 @@ GET     /api/isAdmin                                @controllers.Login.checkIsAd
 GET     /audit/scan                                 @controllers.AuditController.getAll(limit:Option[Int])
 
 GET     /api/vault                                  @controllers.VaultController.knownVaults()
+GET     /api/vault/:vaultId/findDuplicates          @controllers.VaultController.findDuplicates(vaultId)
 GET     /api/metadata/knownTypes                    @controllers.FileListController.getValidTypes
 GET     /api/vault/:vaultId/testFastSearch          @controllers.FileListController.testFastSearch(vaultId, field:String,value:String, quoted:Boolean?=false)
 GET     /api/vault/:vaultId/list                    @controllers.FileListController.pathSearchStreaming(vaultId, forFile:Option[String], sortField:Option[String], sortDir:Option[String], typeFilter:Option[String])

--- a/frontend/app/DuplicateComponent.tsx
+++ b/frontend/app/DuplicateComponent.tsx
@@ -48,9 +48,7 @@ class DuplicateComponent extends React.Component<RouteComponentProps, DuplicateC
       return;
     } else {
       const content = await response.json();
-      this.setState({ duplicatesCount: content.dupes_count });
-      this.setState({ itemCount: content.item_count });
-      this.setState({duplicates: content.duplicates})
+      this.setState({ duplicatesCount: content.dupes_count, itemCount: content.item_count, duplicates: content.duplicates });
     }
 
   }

--- a/frontend/app/DuplicateComponent.tsx
+++ b/frontend/app/DuplicateComponent.tsx
@@ -4,11 +4,6 @@ import { authenticatedFetch } from "./auth";
 import VaultSelector from "./searchnbrowse/NewVaultSelector";
 
 interface DuplicateComponentState {
-  searching?: boolean;
-  fileEntries?: FileEntry[];
-  requestedPreview?: any;
-  currentReader?: ReadableStreamReader<FileEntry>;
-  currentAbort?: any;
   vaultId?: string;
   duplicatesCount?: string;
   itemCount?: string;
@@ -27,17 +22,11 @@ interface DuplicateData {
 }
 
 class DuplicateComponent extends React.Component<RouteComponentProps, DuplicateComponentState> {
-  static resultsLimit = 100;
 
   constructor(props:RouteComponentProps) {
     super(props);
 
     this.state = {
-      searching: false,
-      fileEntries: [],
-      requestedPreview: undefined,
-      currentReader: undefined,
-      currentAbort: undefined,
       vaultId: undefined,
       duplicatesCount: undefined,
       itemCount: undefined,

--- a/frontend/app/DuplicateComponent.tsx
+++ b/frontend/app/DuplicateComponent.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import {RouteComponentProps, withRouter} from "react-router-dom";
+import { authenticatedFetch } from "./auth";
+import VaultSelector from "./searchnbrowse/NewVaultSelector";
+
+interface DuplicateComponentState {
+  searching?: boolean;
+  fileEntries?: FileEntry[];
+  requestedPreview?: any;
+  currentReader?: ReadableStreamReader<FileEntry>;
+  currentAbort?: any;
+  vaultId?: string;
+  duplicatesCount?: string;
+  itemCount?: string;
+  duplicates?: DuplicateEntry[];
+}
+
+interface DuplicateEntry {
+  mxfsPath: string;
+  duplicateNumber: number;
+  duplicatesData: DuplicateData[];
+}
+
+interface DuplicateData {
+  mxfsPath: string;
+  oid: string;
+}
+
+class DuplicateComponent extends React.Component<RouteComponentProps, DuplicateComponentState> {
+  static resultsLimit = 100;
+
+  constructor(props:RouteComponentProps) {
+    super(props);
+
+    this.state = {
+      searching: false,
+      fileEntries: [],
+      requestedPreview: undefined,
+      currentReader: undefined,
+      currentAbort: undefined,
+      vaultId: undefined,
+      duplicatesCount: undefined,
+      itemCount: undefined,
+      duplicates: undefined
+    };
+  }
+
+  async getDuplicateData() {
+    const abortController = new AbortController();
+
+    const response = await authenticatedFetch('/api/vault/'+ this.state.vaultId +'/findDuplicates', {
+      signal: abortController.signal,
+    });
+    if (response.status !== 200) {
+      console.error(`Could not load data: server error ${response.status}`);
+      const rawData = await response.text();
+      console.error(`Server said ${rawData}`);
+
+      return;
+    } else {
+      const content = await response.json();
+      this.setState({ duplicatesCount: content.dupes_count });
+      this.setState({ itemCount: content.item_count });
+      this.setState({duplicates: content.duplicates})
+    }
+
+  }
+
+  componentDidUpdate(prevProps: Readonly<RouteComponentProps>, prevState: Readonly<DuplicateComponentState>, snapshot?: any) {
+    if (this.state.vaultId !== prevState.vaultId) {
+      this.getDuplicateData();
+    }
+  }
+
+  render() {
+    return (
+      <div className="windowpanel">
+        <VaultSelector
+            currentvault={this.state.vaultId ?? ""}
+            vaultWasChanged={(newVault) => {
+              this.setState({ duplicatesCount: undefined });
+              this.setState({ itemCount: undefined });
+              this.setState({ vaultId: newVault });
+            }}
+        />
+        <br />
+        <br />
+        {this.state.duplicatesCount ? (
+            <div>Duplicates in vault: {this.state.duplicatesCount}</div>
+        ) :(<div>Loading duplicate data...</div>)
+        }
+
+        {this.state.itemCount ? (
+            <div>Items in vault: {this.state.itemCount}</div>
+        ) :(null)
+        }
+        <br />
+        <br />
+        {this.state.duplicates ? (
+            this.state.duplicates.map((item,i) => (<div key={i}>Path: {item.mxfsPath}<br/> Duplicates: {item.duplicateNumber}{
+              item.duplicatesData ? (
+              item.duplicatesData.map((itemsub, i) => (
+                  <div key={i}>ObjectMatrix Id.: {itemsub.oid}</div>
+                  )
+              ) ): (null)
+            }
+            <br/><br/></div>))
+        ) : (null)
+        }
+      </div>
+    );
+  }
+}
+
+export default withRouter(DuplicateComponent);

--- a/frontend/app/LoginComponentNew.tsx
+++ b/frontend/app/LoginComponentNew.tsx
@@ -50,7 +50,7 @@ const LoginComponentNew: React.FC<LoginButtonNewProps> = (props) => {
       }
 
       setIsLoggedIn(true);
-    } catch (error) {
+    } catch (error: any) {
       // Login valid callback if provided
       if (props.onLoginValid) {
         props.onLoginValid(false);

--- a/frontend/app/RootComponent.jsx
+++ b/frontend/app/RootComponent.jsx
@@ -47,6 +47,9 @@ class RootComponent extends React.Component {
             <li className="main-menu-list">
               <Link to="/byproject">Go to project browser</Link>
             </li>
+            <li className="main-menu-list">
+              <Link to="/duplicates">Go to find duplicates</Link>
+            </li>
           </ul>
 
           <button style={{ marginLeft: "1em" }} onClick={this.doLogout}>

--- a/frontend/app/index.jsx
+++ b/frontend/app/index.jsx
@@ -18,6 +18,7 @@ import { authenticatedFetch } from "./auth";
 import { ThemeProvider } from "@material-ui/core/styles";
 import { createMuiTheme } from "@material-ui/core";
 import LoginComponentNew from "./LoginComponentNew";
+import DuplicateComponent from "./DuplicateComponent";
 
 class App extends React.Component {
   constructor(props) {
@@ -224,6 +225,7 @@ class App extends React.Component {
             <Switch>
               <Route path="/byproject" component={ByProjectComponent} />
               <Route path="/search" component={SearchComponent} />
+              <Route path="/duplicates" component={DuplicateComponent} />
               <Route
                 exact
                 path="/oauth2/callback"

--- a/frontend/app/projectsearch/ProjectLockerSearchBar.tsx
+++ b/frontend/app/projectsearch/ProjectLockerSearchBar.tsx
@@ -174,7 +174,7 @@ const ProjectLockerSearchBarImplementation: React.FC<ProjectLockerSearchBarProps
       } else {
         setLastError(bodyText);
       }
-    } catch (err) {
+    } catch (err: any) {
       console.error("Could not load initial working group: ", err);
       setLastError(err.toString);
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,7 @@
     "typescript": "^4.2.3",
     "typescript-loader": "^1.1.3",
     "util": "^0.12.3",
-    "webpack": "^5.26.0",
+    "webpack": "^5.61.0",
     "webpack-cli": "^4.5.0",
     "y18n": "4.0.1"
   },


### PR DESCRIPTION
## What does this change?

Adds a basic find duplicates interface which shows the user how many items are duplicated on a vault and some data about each duplicate.

Please note that I have left some code that supplies an internal checksum per item commented out in the code on purpose in case this is of use later.

## How to test

Install on a server and click on the link on the main page.

## How can we measure success?

Data is displayed about duplicates.

## Images

![image](https://user-images.githubusercontent.com/10620802/149554907-8ccee5fa-dbbd-4e80-8eeb-b117e41f5a05.png)


