### PR TITLE
Remove Link to Find Duplicates

### DIFF
--- a/frontend/app/RootComponent.jsx
+++ b/frontend/app/RootComponent.jsx
@@ -47,9 +47,6 @@ class RootComponent extends React.Component {
             <li className="main-menu-list">
               <Link to="/byproject">Go to project browser</Link>
             </li>
-            <li className="main-menu-list">
-              <Link to="/duplicates">Go to find duplicates</Link>
-            </li>
           </ul>
 
           <button style={{ marginLeft: "1em" }} onClick={this.doLogout}>


### PR DESCRIPTION
## What does this change?

Removes the link to find duplicates from the main menu.

This is being done because the current code overloads the servers when run on some vaults.

## How to test

Put the code on a server and see if the link is not present.

## How can we measure success?

The link no longer exists.

