### PR TITLE
Da duplicate four

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -47,8 +47,10 @@ class Application @Inject() (cc:ControllerComponents,
 
   private implicit val timeout:akka.util.Timeout = 30.seconds
 
+  private lazy val vaultDataPath = config.getOptional[String]("vaults.vaultDataPath").getOrElse("/opt/vault_data")
+
   def index = Action {
-    Ok(views.html.index("VaultDoor")("no-cb"))
+    Ok(views.html.index("VaultDoor")("no-cb")(vaultDataPath))
   }
 
   def getMaybeResponseSize(entry:ObjectMatrixEntry, overriden:Option[Long]):Option[Long] = {

--- a/app/controllers/UiController.scala
+++ b/app/controllers/UiController.scala
@@ -21,7 +21,8 @@ class UiController @Inject() (config:Configuration,cc:ControllerComponents) exte
         //logger.warn("Could not get build-sha property: ", e)
         None
     }
-    Ok(views.html.index("VaultDoor")(cbVersionString.getOrElse("no-cachebusting")))
+    lazy val vaultDataPath = config.getOptional[String]("vaults.vaultDataPath").getOrElse("/opt/vault_data")
+    Ok(views.html.index("VaultDoor")(cbVersionString.getOrElse("no-cachebusting"))(vaultDataPath))
   }
 
   def index(tail:String) = rootIndex

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,4 +1,4 @@
-@(title:String)(cacheBuster:String)
+@(title:String)(cacheBuster:String)(vaultDataPath:String)
 <!DOCTYPE html>
 
 <html>
@@ -13,5 +13,8 @@
             background-size: cover;
             background-repeat: no-repeat; min-height: 100vh;'></div>
         <script src="@routes.Assets.at("javascripts/bundle.js")?cb=@(cacheBuster)" type="text/javascript"></script>
+        <script>
+                const VAULT_DATA_PATH="@(vaultDataPath)";
+        </script>
     </body>
 </html>

--- a/build.sbt
+++ b/build.sbt
@@ -2,69 +2,89 @@ import com.typesafe.sbt.packager.docker
 import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.{dockerExposedPorts, dockerUsername}
 import com.typesafe.sbt.packager.docker.{Cmd, DockerPermissionStrategy}
 
-name := "VaultDoor"
- 
-version := "1.0" 
-      
-lazy val `vaultdoor` = (project in file(".")).enablePlugins(PlayScala)
-
-scalaVersion := "2.12.13"
-scalacOptions +="-target:jvm-1.8"
-javacOptions ++= Seq("-source", "1.8","-target","1.8")
-
-libraryDependencies ++= Seq( guice , ehcache, ws , specs2 % Test )
-
-unmanagedResourceDirectories in Test +=  { baseDirectory ( _ /"target/web/public/test" ).value }
-
-unmanagedBase := baseDirectory.value / "lib"
+version := "1.0"
 
 val akkaVersion = "2.5.26"
 val circeVersion = "0.13.0"
 val slf4jVersion = "1.7.25"
 val elastic4sVersion = "6.5.1"
 
-libraryDependencies ++= Seq(
-  "io.circe" %% "circe-core" % circeVersion,
-  "io.circe" %% "circe-generic" % circeVersion,
-  "io.circe" %% "circe-parser" % circeVersion,
-  "com.dripower" %% "play-circe" % "2711.0",
-  "org.slf4j" % "slf4j-api" % slf4jVersion,
-  "commons-codec" % "commons-codec" % "1.13",
-  "commons-io" % "commons-io" % "2.6",
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
-  "com.github.scopt" %% "scopt" % "3.7.1",
-  "io.circe" %% "circe-yaml" % "0.13.0",
-  "org.mongodb.scala" %% "mongo-scala-driver" % "2.6.0",
-  "ai.snips" %% "play-mongo-bson" % "0.5.1",
-  "com.sksamuel.elastic4s" %% "elastic4s-http" % elastic4sVersion,
-  "com.sksamuel.elastic4s" %% "elastic4s-circe" % elastic4sVersion,
-  "com.sksamuel.elastic4s" %% "elastic4s-http-streams" % elastic4sVersion,
-  "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion % "test",
-  "com.sksamuel.elastic4s" %% "elastic4s-embedded" % elastic4sVersion % "test",
-  "com.github.scredis" %% "scredis" % "2.3.3",
-  "org.specs2" %% "specs2-core" % "4.5.1" % Test,
-  "org.specs2" %% "specs2-mock" % "4.5.1" % Test,
-  "org.mockito" % "mockito-core" % "2.28.2" % Test,
-  "com.typesafe.akka" %% "akka-actor" % akkaVersion,
-  "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
-  "com.typesafe.akka" %% "akka-stream" % akkaVersion,
-  "com.typesafe.akka" %% "akka-protobuf" % akkaVersion,
-  "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
+lazy val commonSettings = Seq(
+  scalaVersion := "2.12.13",
+  scalacOptions +="-target:jvm-1.8",
+  javacOptions ++= Seq("-source", "1.8","-target","1.8"),
+  libraryDependencies ++= Seq( guice , ehcache, ws , specs2 % Test ),
+  unmanagedResourceDirectories in Test +=  { baseDirectory ( _ /"target/web/public/test" ).value },
+  unmanagedBase := baseDirectory.value / "lib",
+  libraryDependencies ++= Seq(
+    "io.circe" %% "circe-core" % circeVersion,
+    "io.circe" %% "circe-generic" % circeVersion,
+    "io.circe" %% "circe-parser" % circeVersion,
+    "com.dripower" %% "play-circe" % "2711.0",
+    "org.slf4j" % "slf4j-api" % slf4jVersion,
+    "commons-codec" % "commons-codec" % "1.13",
+    "commons-io" % "commons-io" % "2.6",
+    "ch.qos.logback" % "logback-classic" % "1.2.3",
+    "com.github.scopt" %% "scopt" % "3.7.1",
+    "io.circe" %% "circe-yaml" % "0.13.0",
+    "org.mongodb.scala" %% "mongo-scala-driver" % "2.6.0",
+    "ai.snips" %% "play-mongo-bson" % "0.5.1",
+    "com.sksamuel.elastic4s" %% "elastic4s-http" % elastic4sVersion,
+    "com.sksamuel.elastic4s" %% "elastic4s-circe" % elastic4sVersion,
+    "com.sksamuel.elastic4s" %% "elastic4s-http-streams" % elastic4sVersion,
+    "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion % "test",
+    "com.sksamuel.elastic4s" %% "elastic4s-embedded" % elastic4sVersion % "test",
+    "com.github.scredis" %% "scredis" % "2.3.3",
+    "org.specs2" %% "specs2-core" % "4.5.1" % Test,
+    "org.specs2" %% "specs2-mock" % "4.5.1" % Test,
+    "org.mockito" % "mockito-core" % "2.28.2" % Test,
+    "com.typesafe.akka" %% "akka-actor" % akkaVersion,
+    "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
+    "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+    "com.typesafe.akka" %% "akka-protobuf" % akkaVersion,
+    "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
+  ),
+  //Sentry
+  libraryDependencies += "io.sentry" % "sentry-logback" % "1.7.2",
+  //authentication
+  libraryDependencies ++= Seq(
+    "com.nimbusds" % "nimbus-jose-jwt" % "8.17",
+  ),
+  //snyk updates
+  libraryDependencies ++= Seq(
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.8",
+    "com.google.guava" % "guava" % "30.0-jre",
+    "org.apache.httpcomponents" % "httpclient" % "4.5.13"
+  ),
+  dockerBaseImage := "openjdk:8-jdk-alpine",
+  dockerRepository := Some("guardianmultimedia"),
+  dockerExposedPorts := Seq(9000),
+  dockerPermissionStrategy := DockerPermissionStrategy.Run,
+  daemonUserUid in Docker := None,
+  daemonUser in Docker := "daemon",
+  dockerUsername  := sys.props.get("docker.username"),
+  dockerCommands ++= Seq(
+    Cmd("USER","root"), //fix the permissions in the built docker image
+    Cmd("RUN", "chown daemon /opt/docker"),
+    Cmd("RUN", "chmod u+w /opt/docker"),
+    Cmd("RUN", "chmod -R a+x /opt/docker"),
+    Cmd("USER", "daemon")
+  )
 )
 
-//Sentry
-libraryDependencies += "io.sentry" % "sentry-logback" % "1.7.2"
+lazy val `vaultdoor` = (project in file(".")).settings(
+  commonSettings,
+  name := "VaultDoor",
+  packageName in Docker := "guardianmultimedia/vaultdoor",
+  dockerAlias := docker.DockerAlias(None,Some("guardianmultimedia"),"vaultdoor",Some(sys.props.getOrElse("build.number","DEV"))),
+).enablePlugins(PlayScala)
 
-//authentication
-libraryDependencies ++= Seq(
-  "com.nimbusds" % "nimbus-jose-jwt" % "8.17",
-)
-
-//snyk updates
-libraryDependencies ++= Seq(
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.8",
-  "com.google.guava" % "guava" % "30.0-jre",
-  "org.apache.httpcomponents" % "httpclient" % "4.5.13"
+lazy val `duplicate-finder` = (project in file("duplicate-finder")).enablePlugins(DockerPlugin,AshScriptPlugin).dependsOn(vaultdoor).settings(
+  commonSettings,
+  name := "Duplicate Finder",
+  mainClass in (Compile,run) := Some("Main"),
+  packageName in Docker := "guardianmultimedia/vaultdoor-duplicate-finder",
+  dockerAlias := docker.DockerAlias(None,Some("guardianmultimedia"),"vaultdoor-duplicate-finder",Some(sys.props.getOrElse("build.number","DEV"))),
 )
 
 enablePlugins(RpmPlugin, SystemdPlugin)
@@ -77,20 +97,4 @@ rpmLicense := Some("GPLv2")
 
 enablePlugins(DockerPlugin,AshScriptPlugin)
 version := sys.props.getOrElse("build.number","DEV")
-dockerPermissionStrategy := DockerPermissionStrategy.Run
-daemonUserUid in Docker := None
-daemonUser in Docker := "daemon"
-dockerExposedPorts := Seq(9000)
-dockerUsername  := sys.props.get("docker.username")
-dockerRepository := Some("guardianmultimedia")
-packageName in Docker := "guardianmultimedia/vaultdoor"
 packageName := "vaultdoor"
-dockerBaseImage := "openjdk:8-jdk-alpine"
-dockerAlias := docker.DockerAlias(None,Some("guardianmultimedia"),"vaultdoor",Some(sys.props.getOrElse("build.number","DEV")))
-dockerCommands ++= Seq(
-  Cmd("USER","root"), //fix the permissions in the built docker image
-  Cmd("RUN", "chown daemon /opt/docker"),
-  Cmd("RUN", "chmod u+w /opt/docker"),
-  Cmd("RUN", "chmod -R a+x /opt/docker"),
-  Cmd("USER", "daemon")
-)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -24,6 +24,7 @@ mongodb {
 vaults {
   settings-path="/Users/localhome/Desktop/vaults"
   settings-path=${?VAULT_SETTINGS_PATH}
+  vaultDataPath="/assets/vault_data"
 }
 
 shared_secret = "rubbish"

--- a/duplicate-finder/src/main/scala/Main.scala
+++ b/duplicate-finder/src/main/scala/Main.scala
@@ -1,0 +1,67 @@
+import org.slf4j.LoggerFactory
+import services.DuplicateFinderService
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import helpers.UserInfoCache
+import play.api.Configuration
+import com.typesafe.config.ConfigFactory
+import io.circe.syntax._
+import io.circe.generic.auto._
+import scala.concurrent.ExecutionContext.Implicits.global
+import java.nio.file.{Paths, Files}
+import java.nio.charset.StandardCharsets
+import scala.concurrent.Await
+
+object Main {
+  val logger = LoggerFactory.getLogger(getClass)
+  implicit lazy val actorSystem:ActorSystem = ActorSystem("duplicatefinder")
+  implicit lazy val mat:Materializer = Materializer.matFromSystem(actorSystem)
+
+  def terminate(exitCode:Int) = {
+    import scala.concurrent.duration._
+    try {
+      Await.ready(actorSystem.terminate().andThen({
+        case _ => sys.exit(exitCode)
+      }), 1.hour)
+    } catch {
+      case _:Throwable=>
+        logger.warn("Could not shut down Actor System after one hour.")
+        sys.exit(255)
+    }
+  }
+
+  def main(args: Array[String]): Unit = {
+    val vaultId = sys.env.get("VAULT_ID") match {
+      case None=>
+        logger.error("You must specify VAULT_ID in the environment.")
+        sys.exit(1)
+      case Some(vaultI)=>
+        vaultI
+    }
+
+    val vaultDataOutputPath = sys.env.get("VAULT_DATA_OUTPUT_PATH") match {
+      case None=>
+        logger.error("You must specify VAULT_DATA_OUTPUT_PATH in the environment.")
+        sys.exit(1)
+      case Some(vaultPath)=>
+        vaultPath
+    }
+
+    val conf = ConfigFactory.load()
+    val configObject = new Configuration(conf)
+    val userCache = new UserInfoCache(configObject, actorSystem)
+    val duplicateFinder = new DuplicateFinderService(userCache)
+
+    duplicateFinder.getDuplicateData(vaultId).map(duplicateData=>{
+      val stringContent = duplicateData.asJson.toString()
+      val filePathString = vaultDataOutputPath + "/" + vaultId + ".json"
+      logger.info(s"About to write JSON file to $filePathString.")
+      Files.write(Paths.get(filePathString), stringContent.getBytes(StandardCharsets.UTF_8))
+      terminate(0)
+    }
+    ).recover({
+      case _=>sys.exit(1)
+    })
+  }
+}
+

--- a/frontend/app/RootComponent.jsx
+++ b/frontend/app/RootComponent.jsx
@@ -47,6 +47,9 @@ class RootComponent extends React.Component {
             <li className="main-menu-list">
               <Link to="/byproject">Go to project browser</Link>
             </li>
+            <li className="main-menu-list">
+              <Link to="/duplicates">Go to duplicates data</Link>
+            </li>
           </ul>
 
           <button style={{ marginLeft: "1em" }} onClick={this.doLogout}>

--- a/frontend/app/index.jsx
+++ b/frontend/app/index.jsx
@@ -225,7 +225,7 @@ class App extends React.Component {
             <Switch>
               <Route path="/byproject" component={ByProjectComponent} />
               <Route path="/search" component={SearchComponent} />
-              <Route path="/duplicates" component={DuplicateComponent} />
+              <Route path="/duplicates" component={()=><DuplicateComponent vault_data_path={VAULT_DATA_PATH} />} />
               <Route
                 exact
                 path="/oauth2/callback"


### PR DESCRIPTION
## What does this change?

Adds a new command line module to get data about duplicates and save is an JSON files.

Also adds a simple Web interface to view the data from the JSON files.

## How to test

The new module is designed to be run under Kubernetes. I have added an example config. file for it here: -

https://gitlab.com/codmill/customer-projects/guardian/prexit-local/-/blob/master/kube/vaultdoor/vaultdoor-duplicate-finder.yaml

You will need to change the VAULT_ID setting to the id. of the vault you want to record data on. The front end requires a JSON file per vault to work.

Once you have files for all the vaults your test server talks to, put them in a folder and make sure this folder is accessible to the React code running on your test server. I suggest doing this by either putting a symbolic link in the 'public' folder to the folder your JSON files are in or mounting the volume the JSON files are in at 'public/vault_data'. You can change where the code looks for the JSON files by changing the vaults:vaultDataPath setting in the application.conf file.

With everything setup correctly, you should be able to click on the 'Go to duplicates data' link and view data on each vault which has a corresponding JSON file present using the menu to switch between vaults.

## Images

![image](https://user-images.githubusercontent.com/10620802/162199679-28a4b345-4f7e-4568-af71-ea4617c0ee7b.png)


