### PR TITLE
Use MXFS_PATH

### DIFF
--- a/app/streamcomponents/MakeDownloadSynopsis.scala
+++ b/app/streamcomponents/MakeDownloadSynopsis.scala
@@ -54,7 +54,7 @@ class MakeDownloadSynopsis (maybeStripPrefixes:Option[Seq[String]]) extends Grap
       override def onPush(): Unit = {
         val elem = grab(in)
 
-        val maybeFilePath = elem.attributes.flatMap(_.stringValues.get("MXFS_FILENAME").map(strippedPrefix))
+        val maybeFilePath = elem.attributes.flatMap(_.stringValues.get("MXFS_PATH").map(strippedPrefix))
         val maybeFileSize = determineSize(elem)
         val result = ArchiveEntryDownloadSynopsis(elem.oid, maybeFilePath.getOrElse(""), maybeFileSize)
         push(out, result)


### PR DESCRIPTION
## What does this change?

Use MXFS_PATH instead of MXFS_FILENAME.

## How can we measure success?

The folder structure is now recreated on using the bulk download feature.

Tested on the dev. system.